### PR TITLE
Data Service modified to expand the usage of HTTP calls and also be testable

### DIFF
--- a/src/app/admin/interface/contact.ts
+++ b/src/app/admin/interface/contact.ts
@@ -1,5 +1,0 @@
-export interface IContact {
-    phone: string;
-    email: string;
-    person: string;
-}

--- a/src/app/admin/interface/organization.ts
+++ b/src/app/admin/interface/organization.ts
@@ -1,11 +1,28 @@
-import { IContact } from './contact';
+interface Contact {
+    phone: string;
+    email: string;
+    person: string;
+}
 
+export interface Organization {
+    id: number;
+    orgId: string;
+    name: string;
+    address: string;
+    contact: Contact;
+    password: string;
+    billing: string;
+    description: string;
+}
+
+
+// Depricated
 export interface IOrganization {
     id: number;
     orgId: string;
     name: string;
     address: string;
-    contact: IContact;
+    contact: Contact;
     password: string;
     billing: string;
     description: string;

--- a/src/app/admin/interface/project.ts
+++ b/src/app/admin/interface/project.ts
@@ -1,0 +1,14 @@
+export interface Project {
+    id: number;
+    projectName: string;
+    toDate: string;
+    fromDate: string;
+    address: string;
+    neededFunding: number;
+    raisedFunding: number;
+    description: string;
+    mainImage: string;
+    projectManager: string;
+    projectId: string;
+    organizationName: string;
+}

--- a/src/app/admin/services/data.service.ts
+++ b/src/app/admin/services/data.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/Observable/throw';
+
+// Interfaces
+import { Organization } from '../interface/organization';
+import { Project } from '../interface/project';
 
 @Injectable()
 export class DataService {
@@ -13,12 +17,26 @@ export class DataService {
     projects: 'projects.json'
   };
 
-  private _get(path: string): Observable<any> {
+  // Updated!
+  // Doesn't break code which calls this function.
+  private _get(path: string, options?: Object): Observable<any> {
     if (path === undefined) {
       return;
     }
 
-    return this.http.get(path)
+    if (options !== undefined && Object.keys(options).length > 0) {
+      let params = new HttpParams();
+
+      for (const option in options) {
+        if (options.hasOwnProperty(option)) {
+          const value = options[option];
+          params.set(option, value);
+        }
+      }
+
+      return this.http.get(path, {
+        params: params
+      })
       .do((data: Response) => {
         return data !== undefined ? data : [];
       })
@@ -26,6 +44,16 @@ export class DataService {
         console.log(error['message']);
         return Observable.throw(error || 'Server error');
       });
+    } else {
+      return this.http.get(path)
+      .do((data: Response) => {
+        return data !== undefined ? data : [];
+      })
+      .catch((error: Response) => {
+        console.log(error['message']);
+        return Observable.throw(error || 'Server error');
+      });
+    }
   }
 
   private _set(path: string, data: any): boolean {
@@ -35,6 +63,8 @@ export class DataService {
     return _inserted;
   }
 
+  // DEPRICATED!
+  // Use either of getOrganizations/getProjects/getOrganization(arg)/getProject(arg)!
   // tslint:disable-next-line:member-ordering
   get = {
     organizations: (): any => {
@@ -45,15 +75,39 @@ export class DataService {
     }
   };
 
-  // tslint:disable-next-line:member-ordering
-  set = {
-    organizations: (data: any): boolean => {
-      return this._set(data, this.paths.root + this.paths.organizations);
-    },
-    projects: (data: any): boolean => {
-      return this._set(data, this.paths.root + this.paths.projects);
+  // Get all Organizations records data from the path. Requires no arguments to input.
+  // Returns a set of Organization (interface) Observable.
+  getOrganizations(): Observable<Organization> {
+    return this._get(this.paths.root + this.paths.organizations);
+  }
+
+  // Get only 1 Organization record data with parameterized query. options is an Object argument which
+  // should have at least 1 property + value.
+  // Returns a Organization (interface) Observable.
+  getOrganization(options: Object): Observable<Organization> {
+    if (options === undefined || typeof options === 'object' || Object.keys(options).length <= 0) {
+      return;
     }
-  };
+
+    return this._get(this.paths.root + this.paths.organizations, options);
+  }
+
+  // Get all Projects records data from the path. Requires no arguments to input.
+  // Returns a set of Project (interface) Observable.
+  getProjects(): Observable<Project> {
+    return this._get(this.paths.root + this.paths.projects);
+  }
+
+  // Get only 1 Project record data with parameterized query. options is an Object argument which
+  // should have at least 1 property + value.
+  // Returns a Project (interface) Observable.
+  getProject(options: Object): Observable<Project> {
+    if (options === undefined || typeof options === 'object' || Object.keys(options).length <= 0) {
+      return;
+    }
+
+    return this._get(this.paths.root + this.paths.projects, options);
+  }
 
   constructor(private http: HttpClient) { }
 }


### PR DESCRIPTION
In this pull, I've managed to cover some of the formentioned issues of testing also requests to expand the usage of the data service. Now it includes single record GET HTTP calls parameterized with provided arguments e.g. {id: 3} or multiple {id: 3, name: "something"} if the need be. That way it, once we get API stabilized and provided with a liable database then it is possible to directly request with these functions.