### PR TITLE
Important app upgrade: please read and test before approving

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.3.2.
 
+# Important application upgrade instructions
+
+Major upgrades were implemented after sprint 2. If you want have an older development version, you need to run 
+    - `git checkout development`
+    - `git pull`
+    - `npm install`
+
+then rebase your branches with development
+
 # GIT clone and installation (only for the first start)
 
 Visual Studio Code open in view menu open Integrated Terminal:
@@ -34,3 +43,20 @@ Before running the tests make sure you are serving the app via `ng serve`.
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+# Application changes after sprint 2
+
+  - Updated angular and its libraries from 4.2.4 to 4.4.4
+  - updated angular/cli from 1.3.2 to 1.4.5, and made it updatable.
+  - updated angular/material from 2.0.0-beta.10 to 2.0.0-beta.12
+  - updated zone.js from 0.8.14 to 0.8.18
+  - added webpack as a local dev dependency
+
+  - updated all references to material modules and components to use the new mat namespace in all modules and components
+
+  - moved all material imports in admin module to the shared module
+  - moved forms imports from admin module to the shared module
+  - moved browser imports from admin module to the shared module
+  - removed http import from admin module
+  - removed material imports from all spec files as they are imported from the shared module
+  - Fixed imports and declaration in the navbar spec file

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,132 +2,23 @@
   "name": "twbiv-frontend",
   "version": "0.0.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
-    "@angular-devkit/build-optimizer": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.13.tgz",
-      "integrity": "sha512-yEMkYU4YU8XlA5OauPhg22ZEWJ4X2VhiFKUwfeo4UWJ7lz4XWiuBJocrT5NHWqI1S0rOLpSixLXG9byvFMbavA==",
+    "@agm/core": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@agm/core/-/core-1.0.0-beta.1.tgz",
+      "integrity": "sha512-IVwQGmcaE42SmYY2e5QwqOC0vrSXZCW8BhATY0Vpy3NjbiydSXi9T81hVqKLvuKaB3ves1sv3W++SB1Wj+5B6A=="
+    },
+    "@angular-devkit/core": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.17.tgz",
+      "integrity": "sha512-pbf3r3/v2OKZG6vVJHdNFlXCV85/yMANEr9Y8PX2e8aKn4vr8e4ZE/bD+s8Z/Xf8XBYFeqG6ges3c+GnLJhfAg==",
+      "dev": true
+    },
+    "@angular-devkit/schematics": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.30.tgz",
+      "integrity": "sha512-ThaRG3Y/jLxRD7XpQbgqUEnJvBCjihnb28ki+vB45kt6irV2pM1U0ZvdFfpiW+fxX3r0mAOtxo+4TPKlBEZdaw==",
       "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "source-map": "0.5.7",
-        "typescript": "2.3.4"
-      }
-    },
-    "@angular/animations": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.4.2.tgz",
-      "integrity": "sha1-UNkmb6poG0KL9vqSC992RHaHqdU=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
-    },
-    "@angular/cdk": {
-      "version": "2.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.10.tgz",
-      "integrity": "sha512-G0RvzxItfPy8JEdnyV/10GryE3zHehm3bUJ7U9dwYKhAzhye+MX0P6rs8VEmbClJb5SuZDr0ZZ53vbHhHsUh6A==",
-      "requires": {
-        "tslib": "1.7.1"
-      }
-    },
-    "@angular/cli": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.3.2.tgz",
-      "integrity": "sha512-VAZXI19PbhhUE/dJH5r6HT7502y0OXYzxhbGIagh/e7SNKnVV8KglVL4zfTfnsI8kmLrFFbAmPy7xomKO8Btkg==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/build-optimizer": "0.0.13",
-        "@ngtools/json-schema": "1.1.0",
-        "@ngtools/webpack": "1.6.2",
-        "autoprefixer": "6.7.7",
-        "chalk": "2.1.0",
-        "circular-dependency-plugin": "3.0.0",
-        "common-tags": "1.4.0",
-        "core-object": "3.1.5",
-        "css-loader": "0.28.7",
-        "cssnano": "3.10.0",
-        "denodeify": "1.2.1",
-        "diff": "3.3.1",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "exports-loader": "0.6.4",
-        "extract-text-webpack-plugin": "3.0.0",
-        "file-loader": "0.10.1",
-        "fs-extra": "4.0.2",
-        "get-caller-file": "1.0.2",
-        "glob": "7.1.2",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "html-webpack-plugin": "2.30.1",
-        "inflection": "1.12.0",
-        "inquirer": "3.3.0",
-        "isbinaryfile": "3.0.2",
-        "istanbul-instrumenter-loader": "2.0.0",
-        "karma-source-map-support": "1.2.0",
-        "less": "2.7.2",
-        "less-loader": "4.0.5",
-        "license-webpack-plugin": "0.5.1",
-        "lodash": "4.17.4",
-        "memory-fs": "0.4.1",
-        "minimatch": "3.0.4",
-        "node-modules-path": "1.0.1",
-        "node-sass": "4.5.3",
-        "nopt": "4.0.1",
-        "opn": "5.1.0",
-        "portfinder": "1.0.13",
-        "postcss-loader": "1.3.3",
-        "postcss-url": "5.1.2",
-        "raw-loader": "0.5.1",
-        "resolve": "1.4.0",
-        "rsvp": "3.6.2",
-        "rxjs": "5.4.3",
-        "sass-loader": "6.0.6",
-        "script-loader": "0.7.1",
-        "semver": "5.4.1",
-        "silent-error": "1.1.0",
-        "source-map-loader": "0.2.1",
-        "source-map-support": "0.4.18",
-        "style-loader": "0.13.2",
-        "stylus": "0.54.5",
-        "stylus-loader": "3.0.1",
-        "temp": "0.8.3",
-        "typescript": "2.3.4",
-        "url-loader": "0.5.9",
-        "walk-sync": "0.3.2",
-        "webpack": "3.4.1",
-        "webpack-dev-middleware": "1.12.0",
-        "webpack-dev-server": "2.5.1",
-        "webpack-merge": "4.1.0",
-        "zone.js": "0.8.17"
-      }
-    },
-    "@angular/common": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.4.2.tgz",
-      "integrity": "sha1-coCE9TgQb/yC0RiVoZD9gc/kSIE=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
-    },
-    "@angular/compiler": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.4.2.tgz",
-      "integrity": "sha1-AoeQ9sWin+X1+301Lq284b7+SZs=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
-    },
-    "@angular/compiler-cli": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.4.2.tgz",
-      "integrity": "sha1-mvYF5gogSRbZq/QhOKZyrzjDDWA=",
-      "dev": true,
-      "requires": {
-        "@angular/tsc-wrapped": "4.4.2",
-        "minimist": "1.2.0",
-        "reflect-metadata": "0.1.10"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -137,76 +28,324 @@
         }
       }
     },
-    "@angular/core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.2.tgz",
-      "integrity": "sha1-e7UDecT4NtPIWf6S1t/pIwarFQA=",
-      "requires": {
-        "tslib": "1.7.1"
+    "@angular/animations": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.4.4.tgz",
+      "integrity": "sha1-ovk1NgQ0er4V35gpIFiEL1Lwi8I="
+    },
+    "@angular/cdk": {
+      "version": "2.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.12.tgz",
+      "integrity": "sha1-OiQ8tiuT9OA5EgunD5ANyeI1Yi4="
+    },
+    "@angular/cli": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.4.5.tgz",
+      "integrity": "sha512-KH3AQnA19qOj25JVRCB3udWWb5aeezbeERYflCUGMvWsMyEe5vzZP3s6flUdy5Xsjb1UDXhqdqaKu64HP/zeEA==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/build-optimizer": {
+          "version": "0.0.25",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.25.tgz",
+          "integrity": "sha512-P3JyfQQb8UT4P/bWyskh9z2zl7rzwBA70yYzAtIGPAFfMvAIoX2564nzI63mnYyIRx7nvG3GKssSIl/KZlg0Jw==",
+          "dev": true
+        },
+        "@ngtools/webpack": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.7.2.tgz",
+          "integrity": "sha512-psx2OTM0ytyXobYG5YdFWDrKn8gDyWpgIYiZAJVsQnGGxU7bCbY7ObLq9pMdAJUY80NJurXLCXXVNxPLTjg1VQ==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true
+        },
+        "license-webpack-plugin": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-1.1.0.tgz",
+          "integrity": "sha512-4f0H9kk1y4BF8/y8V4p8pn/ZAoZaCsCnfJfoVvq5t+jkjWJKhSKzROdzeJPNDcZj/tSzJ4NkXjcH0hXaagxLJA==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+          "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true
+        },
+        "url-loader": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
+          "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+          "dev": true
+        },
+        "webpack": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.6.0.tgz",
+          "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
+          "dev": true
+        },
+        "webpack-dev-server": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.7.1.tgz",
+          "integrity": "sha1-IVgPWgjNBlxxFEz29hw0W8pZqLg=",
+          "dev": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+              "dev": true
+            },
+            "opn": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+              "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+              "dev": true
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+              "dev": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+              "dev": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+              "dev": true
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true
+            },
+            "which-module": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+              "dev": true
+            },
+            "yargs": {
+              "version": "6.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+              "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+              "dev": true
+            },
+            "yargs-parser": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+              "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+              "dev": true
+            }
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true
+        }
       }
+    },
+    "@angular/common": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.4.4.tgz",
+      "integrity": "sha1-rgqBiqoMaj8JAee4C9lOHCLrk2U="
+    },
+    "@angular/compiler": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.4.4.tgz",
+      "integrity": "sha1-Mm6wAp2aNUGqyhJN75rcUcNvK0E="
+    },
+    "@angular/compiler-cli": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.4.4.tgz",
+      "integrity": "sha1-BjCApJfZF1OWglBQIixxfaGE9s8=",
+      "dev": true,
+      "dependencies": {
+        "@angular/tsc-wrapped": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.4.4.tgz",
+          "integrity": "sha1-mEGCHlVha4JsoWAlD+heFfx0/8M=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "@angular/core": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.4.tgz",
+      "integrity": "sha1-vTfs9UFY+XSJmWyThr0iL4CjL1w="
     },
     "@angular/forms": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.4.2.tgz",
-      "integrity": "sha1-Z2OrCaUVdgdJyspn6JjSRWBSyx4=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.4.4.tgz",
+      "integrity": "sha1-TbN5BQm2sQ8duKfBt/Uhh89kz9Q="
     },
     "@angular/http": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.4.2.tgz",
-      "integrity": "sha1-wMG8Ka1Jr7vf4GO63jk/0KoaPn0=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.4.4.tgz",
+      "integrity": "sha1-Zn+vYWu2JBaOr65u6S5euiOp0fI="
     },
     "@angular/language-service": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-4.4.2.tgz",
-      "integrity": "sha1-wYBqG5L9L6flQCv3o/utQM0Etcg=",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-4.4.4.tgz",
+      "integrity": "sha1-D2hgUuOVDBkSjxO3Qp/BS6/mm9Q=",
       "dev": true
     },
     "@angular/material": {
-      "version": "2.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.10.tgz",
-      "integrity": "sha512-KAQ2t9wenI55oXkjjT6E4VGUSVu7AZmR+ytnaP96VBFk18wxcGnVaTbQmCvVm/vkbcdeoSF09D6ic94DHAE+1A==",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "version": "2.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.12.tgz",
+      "integrity": "sha1-cbbQt7AhiR5dDjaIwdS9eMdFf1g="
     },
     "@angular/platform-browser": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.4.2.tgz",
-      "integrity": "sha1-+t9RiU24BOOiG2l4/2GDjB5MGTo=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.4.4.tgz",
+      "integrity": "sha1-o4mOLnup2E/6DUcUTGlxF5x1ruY="
     },
     "@angular/platform-browser-dynamic": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.4.2.tgz",
-      "integrity": "sha1-wZncCp4P8gxa6ByQSIiO0mdOISg=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.4.4.tgz",
+      "integrity": "sha1-w8nrhUpShVagcFQSeTLlJ/qTLhQ="
     },
     "@angular/router": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.4.2.tgz",
-      "integrity": "sha1-ZCC7e54YVVMXx8HRNOBEA09iyeo=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
-    },
-    "@angular/tsc-wrapped": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.4.2.tgz",
-      "integrity": "sha1-jCj/DRmzK5soG0y0NNJYdvwazWA=",
-      "dev": true,
-      "requires": {
-        "tsickle": "0.21.6"
-      }
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.4.4.tgz",
+      "integrity": "sha1-e+ORCW6EPLPgT58F0dZaiN+bx88="
     },
     "@ngtools/json-schema": {
       "version": "1.1.0",
@@ -214,16 +353,11 @@
       "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=",
       "dev": true
     },
-    "@ngtools/webpack": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.6.2.tgz",
-      "integrity": "sha512-2s2kCCV3FQUC+MG69e+H5k7zELuVcQ0Gkl1ioqR25HOclxv0UGVY7jsmz9LRm/DanS5ORXQt4S82EFV1dY4w+A==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "magic-string": "0.22.4",
-        "source-map": "0.5.7"
-      }
+    "@schematics/angular": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.0.41.tgz",
+      "integrity": "sha512-y+EEWdVWeOedJbCwHG/MJbl/Tqulqb6glnJmzBak5brWZv2HL66RRWBixFTdYOs0oSRrbzBFPO+bXIS1xVoItw==",
+      "dev": true
     },
     "@types/jasmine": {
       "version": "2.5.54",
@@ -235,10 +369,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.3.tgz",
       "integrity": "sha512-hYDVmQZT5VA2kigd4H4bv7vl/OhlympwREUemqBdOqtrYTo5Ytm12a5W5/nGgGYdanGVxj0x/VhZ7J3hOg/YKg==",
-      "dev": true,
-      "requires": {
-        "@types/jasmine": "2.5.54"
-      }
+      "dev": true
     },
     "@types/node": {
       "version": "6.0.88",
@@ -268,11 +399,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
-      "requires": {
-        "mime-types": "2.1.17",
-        "negotiator": "0.6.1"
-      }
+      "dev": true
     },
     "acorn": {
       "version": "5.1.2",
@@ -285,9 +412,6 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -314,10 +438,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
-      "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
       "dependencies": {
         "semver": {
           "version": "5.0.3",
@@ -331,13 +451,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
       "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
-      }
+      "dev": true
     },
     "ajv-keywords": {
       "version": "2.1.0",
@@ -349,12 +463,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -366,12 +475,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-html": {
@@ -396,11 +499,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
+      "dev": true
     },
     "app-root-path": {
       "version": "2.0.1",
@@ -412,10 +511,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "1.0.0"
-      }
+      "dev": true
     },
     "aproba": {
       "version": "1.1.2",
@@ -428,10 +524,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -443,25 +535,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -469,19 +549,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -511,10 +585,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -557,21 +628,13 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -583,10 +646,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -611,15 +671,7 @@
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000733",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -638,24 +690,12 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -670,16 +710,6 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
@@ -693,62 +723,31 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
-      }
+      "dev": true
     },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
+      "dev": true
     },
     "babylon": {
       "version": "6.18.0",
@@ -797,19 +796,13 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true,
-      "requires": {
-        "callsite": "1.0.0"
-      }
+      "dev": true
     },
     "big.js": {
       "version": "3.2.0",
@@ -834,19 +827,13 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "optional": true
     },
     "blocking-proxy": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-0.0.5.tgz",
       "integrity": "sha1-RikF4Nz76pcPQao3Ij3anAexkSs=",
       "dev": true,
-      "requires": {
-        "minimist": "1.2.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -873,18 +860,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz",
       "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
       "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "1.0.4",
-        "debug": "2.6.8",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "1.6.15"
-      },
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
@@ -904,15 +879,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "dev": true,
-      "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.1.1",
-        "multicast-dns-service-types": "1.1.0"
-      }
+      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -924,20 +891,13 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      },
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
@@ -951,12 +911,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "dev": true
     },
     "brorand": {
       "version": "1.1.0",
@@ -968,92 +923,49 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
       "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
-      "dev": true,
-      "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "browserify-cipher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "1.0.8",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
-      }
+      "dev": true
     },
     "browserify-des": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
-      }
+      "dev": true
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true,
-      "requires": {
-        "pako": "0.2.9"
-      }
+      "dev": true
     },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true,
-      "requires": {
-        "caniuse-db": "1.0.30000733",
-        "electron-to-chromium": "1.3.21"
-      }
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
-      "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1103,11 +1015,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
-      "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
-      }
+      "dev": true
     },
     "camelcase": {
       "version": "2.1.1",
@@ -1119,23 +1027,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      }
+      "dev": true
     },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-      "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000733",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
-      }
+      "dev": true
     },
     "caniuse-db": {
       "version": "1.0.30000733",
@@ -1154,10 +1052,6 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      },
       "dependencies": {
         "lazy-cache": {
           "version": "1.0.4",
@@ -1172,20 +1066,12 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
       "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
@@ -1197,38 +1083,27 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "circular-dependency-plugin": {
       "version": "3.0.0",
@@ -1241,22 +1116,12 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.2.tgz",
       "integrity": "sha1-aD9vk6MgeU0Sk4bXSyodLWb+3n4=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -1270,24 +1135,6 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
       "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -1295,31 +1142,18 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1333,13 +1167,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
       "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
-      "dev": true,
-      "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "shallow-clone": "0.1.2"
-      }
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -1351,10 +1179,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1366,35 +1191,19 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-3.1.2.tgz",
       "integrity": "sha1-n/HwQfubXuXb60W6hm368EmDrwQ=",
-      "dev": true,
-      "requires": {
-        "app-root-path": "2.0.1",
-        "css-selector-tokenizer": "0.7.0",
-        "cssauron": "1.4.0",
-        "semver-dsl": "1.0.1",
-        "source-map": "0.5.7",
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "color": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.2",
-        "color-convert": "1.9.0",
-        "color-string": "0.3.0"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.3",
@@ -1406,21 +1215,13 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true,
-      "requires": {
-        "color": "0.11.4",
-        "css-color-names": "0.0.4",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -1432,19 +1233,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
@@ -1456,10 +1251,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
       "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1483,25 +1275,13 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
       "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.30.0"
-      }
+      "dev": true
     },
     "compression": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
       "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "bytes": "2.5.0",
-        "compressible": "2.0.11",
-        "debug": "2.6.8",
-        "on-headers": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "1.1.1"
-      }
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1514,27 +1294,12 @@
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
       "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
       "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "finalhandler": "1.0.4",
-        "parseurl": "1.3.2",
-        "utils-merge": "1.0.0"
-      },
       "dependencies": {
         "finalhandler": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
           "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.8",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -1548,10 +1313,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "0.1.4"
-      }
+      "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -1595,6 +1357,38 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.1.1.tgz",
+      "integrity": "sha512-qcjV9uj5PFuKo9GDr0xYAZ3DwFA3ugwDcfbLHfiDrvnUx66Z7C4r00/ds856GaGb2cGHqLTwrGxwfvW+lgAQew==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true
+        }
+      }
+    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -1604,10 +1398,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/core-object/-/core-object-3.1.5.tgz",
       "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.1.0"
-      }
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1620,15 +1411,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
-      "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.7.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1642,75 +1424,44 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
-      }
+      "dev": true
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "create-hmac": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
-      }
+      "optional": true
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.11.1",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
       "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
-      "dev": true,
-      "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -1722,23 +1473,7 @@
       "version": "0.28.7",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
       "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "2.0.0"
-      }
+      "dev": true
     },
     "css-parse": {
       "version": "1.7.0",
@@ -1750,24 +1485,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
-        "domutils": "1.5.1",
-        "nth-check": "1.0.1"
-      }
+      "dev": true
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-      "dev": true,
-      "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
-      }
+      "dev": true
     },
     "css-what": {
       "version": "2.1.0",
@@ -1779,10 +1503,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
       "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "cssesc": {
       "version": "0.1.0",
@@ -1794,60 +1515,19 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
-      }
+      "dev": true
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true,
-      "requires": {
-        "clap": "1.2.2",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "dev": true
     },
     "custom-event": {
       "version": "1.0.1",
@@ -1859,19 +1539,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.30"
-      }
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1891,10 +1565,7 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1912,10 +1583,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "2.0.0"
-      }
+      "dev": true
     },
     "defined": {
       "version": "1.0.0",
@@ -1928,14 +1596,6 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
-      "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
@@ -1973,11 +1633,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
@@ -1989,10 +1645,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "detect-node": {
       "version": "2.0.3",
@@ -2016,44 +1669,25 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "directory-encoder": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.7.2.tgz",
       "integrity": "sha1-WbTiqk8lQi9sY7UntGL14tDdLFg=",
       "dev": true,
-      "requires": {
-        "fs-extra": "0.23.1",
-        "handlebars": "1.3.0",
-        "img-stats": "0.5.2"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "0.23.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
           "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
+          "dev": true
         }
       }
     },
@@ -2067,29 +1701,19 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
       "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
-      "dev": true,
-      "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "dns-txt": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "dev": true,
-      "requires": {
-        "buffer-indexof": "1.1.1"
-      }
+      "dev": true
     },
     "dom-converter": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
-      "requires": {
-        "utila": "0.3.3"
-      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -2103,23 +1727,13 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
-      "dev": true,
-      "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "void-elements": "2.0.1"
-      }
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -2145,35 +1759,31 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
       "dev": true
     },
     "electron-to-chromium": {
@@ -2186,25 +1796,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
-    },
-    "ember-cli-normalize-entity-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
-      "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-      "dev": true,
-      "requires": {
-        "silent-error": "1.1.0"
-      }
+      "dev": true
     },
     "ember-cli-string-utils": {
       "version": "1.1.0",
@@ -2229,33 +1821,18 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
       "integrity": "sha1-jef5eJXSDTm4X4ju7nd7K9QrE9Q=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "ws": "1.1.2"
-      },
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.17",
-            "negotiator": "0.6.1"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -2270,20 +1847,6 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
       "integrity": "sha1-F5jtk0USRkU9TG9jXXogH+lA1as=",
       "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.2",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -2295,10 +1858,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -2312,32 +1872,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-      "dev": true,
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.7",
-        "wtf-8": "1.0.0"
-      }
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
-    },
-    "ensure-posix-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
       "dev": true
     },
     "ent": {
@@ -2356,89 +1896,49 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
-      "requires": {
-        "prr": "0.0.0"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "dev": true
     },
     "es5-ext": {
       "version": "0.10.30",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
       "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2456,13 +1956,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "2.7.3",
@@ -2474,11 +1968,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2502,11 +1992,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
-      }
+      "dev": true
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -2524,46 +2010,25 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true,
-      "requires": {
-        "original": "1.0.0"
-      }
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
-      "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      },
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2578,30 +2043,18 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
-      "requires": {
-        "array-slice": "0.2.3",
-        "array-unique": "0.2.1",
-        "braces": "0.1.5"
-      },
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-          "dev": true,
-          "requires": {
-            "expand-range": "0.1.1"
-          }
+          "dev": true
         },
         "expand-range": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true,
-          "requires": {
-            "is-number": "0.1.1",
-            "repeat-string": "0.2.2"
-          }
+          "dev": true
         },
         "is-number": {
           "version": "0.1.1",
@@ -2621,65 +2074,25 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "dev": true
     },
     "exports-loader": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
       "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "express": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
       "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "array-flatten": "1.1.1",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.0.5",
-        "fresh": "0.5.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
-        "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
-      },
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
@@ -2701,37 +2114,17 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
-    "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
-        "tmp": "0.0.33"
-      }
-    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "extract-text-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.0.tgz",
       "integrity": "sha1-kMqnkHvESfM1AF46x1MrQbAN5hI=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.0.1"
-      }
+      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -2755,28 +2148,13 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true,
-      "requires": {
-        "websocket-driver": "0.7.0"
-      }
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
+      "dev": true
     },
     "file-loader": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
       "integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0"
-      }
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2788,24 +2166,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2817,10 +2184,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2828,26 +2192,13 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
       "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      }
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "flatten": {
       "version": "1.0.2",
@@ -2865,10 +2216,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2880,12 +2228,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2903,21 +2246,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true,
-      "requires": {
-        "null-check": "1.0.0"
-      }
+      "dev": true
     },
     "fs-extra": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
       "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
-      }
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2925,17 +2260,668 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2948,36 +2934,18 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -2986,10 +2954,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "globule": "1.2.0"
-      }
+      "optional": true
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -3014,9 +2979,6 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3030,34 +2992,19 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
@@ -3069,26 +3016,14 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "globule": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
-      }
+      "optional": true
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3112,10 +3047,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "dev": true,
-      "requires": {
-        "optimist": "0.3.7",
-        "uglify-js": "2.3.6"
-      },
       "dependencies": {
         "async": {
           "version": "0.2.10",
@@ -3129,22 +3060,14 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "optional": true
         },
         "uglify-js": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          }
+          "optional": true
         }
       }
     },
@@ -3159,20 +3082,12 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      },
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3180,28 +3095,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
@@ -3225,32 +3131,19 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -3258,43 +3151,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "heimdalljs": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
-      "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-      "dev": true,
-      "requires": {
-        "rsvp": "3.2.1"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
-        }
-      }
-    },
-    "heimdalljs-logger": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
-      "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "heimdalljs": "0.2.5"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "dev": true
     },
     "hoek": {
       "version": "2.16.3",
@@ -3313,12 +3174,6 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -3330,25 +3185,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3368,43 +3211,19 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.5.tgz",
       "integrity": "sha512-g+1+NBycQI0fGnggd52JM8TRUweG7+9W2wrtjGitMAqc4G7maweAHvVAAjz9veHseIH3tYKE2lk2USGSoewIrQ==",
-      "dev": true,
-      "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.9",
-        "commander": "2.11.0",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.1.1"
-      }
+      "dev": true
     },
     "html-webpack-plugin": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "html-minifier": "3.5.5",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.3"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3413,21 +3232,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.1.0",
-        "domutils": "1.1.6",
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "domutils": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
+          "dev": true
         }
       }
     },
@@ -3441,13 +3251,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
-      "requires": {
-        "depd": "1.1.1",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      }
+      "dev": true
     },
     "http-parser-js": {
       "version": "0.4.6",
@@ -3459,23 +3263,13 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
-      }
+      "dev": true
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
-      "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11"
-      },
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
@@ -3487,10 +3281,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3498,12 +3289,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
+      "dev": true
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -3515,12 +3301,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.8",
-        "extend": "3.0.1"
-      }
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -3539,9 +3320,6 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
-      "requires": {
-        "postcss": "6.0.11"
-      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -3553,21 +3331,13 @@
           "version": "6.0.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -3588,10 +3358,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.5.2.tgz",
       "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
-      "dev": true,
-      "requires": {
-        "xmldom": "0.1.27"
-      }
+      "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
@@ -3604,10 +3371,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -3621,21 +3385,11 @@
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
-    "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -3649,53 +3403,11 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
     "internal-ip": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "dev": true,
-      "requires": {
-        "meow": "3.7.0"
-      }
+      "dev": true
     },
     "interpret": {
       "version": "1.0.4",
@@ -3707,10 +3419,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3746,10 +3455,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "1.10.0"
-      }
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -3761,10 +3467,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "dev": true
     },
     "is-directory": {
       "version": "0.3.1",
@@ -3782,10 +3485,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3803,10 +3503,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -3818,19 +3515,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3842,19 +3533,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.0"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -3866,10 +3551,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      }
+      "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3883,12 +3565,6 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3899,10 +3575,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true,
-      "requires": {
-        "html-comment-regex": "1.1.1"
-      }
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3956,44 +3629,19 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.8.0",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
-      }
+      "dev": true
     },
     "istanbul-instrumenter-loader": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-2.0.0.tgz",
       "integrity": "sha1-5UkpAKsLuoNe+oAkywC+mz7qJwA=",
       "dev": true,
-      "requires": {
-        "convert-source-map": "1.5.0",
-        "istanbul-lib-instrument": "1.8.0",
-        "loader-utils": "0.2.17",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -4007,59 +3655,31 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "0.4.0"
-      }
+      "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
       "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
-      }
+      "dev": true
     },
     "istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
-      }
+      "dev": true
     },
     "istanbul-lib-source-maps": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "istanbul-reports": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "dev": true,
-      "requires": {
-        "handlebars": "4.0.10"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -4080,11 +3700,6 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -4099,32 +3714,19 @@
           "version": "4.0.10",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          }
+          "dev": true
         },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
@@ -4132,11 +3734,6 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
@@ -4152,13 +3749,7 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+          "optional": true
         }
       }
     },
@@ -4167,11 +3758,6 @@
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
       "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
-      },
       "dependencies": {
         "jasmine-core": {
           "version": "2.8.0",
@@ -4191,10 +3777,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.1.1.tgz",
       "integrity": "sha1-Wm1Yq11hvqcwn7wnkjlRF1axtYg=",
-      "dev": true,
-      "requires": {
-        "colors": "1.1.2"
-      }
+      "dev": true
     },
     "jasminewd2": {
       "version": "2.1.0",
@@ -4218,11 +3801,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
-      }
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -4230,12 +3809,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
-    },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
-      "dev": true
     },
     "jsesc": {
       "version": "0.5.0",
@@ -4265,10 +3838,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4292,10 +3862,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4308,12 +3875,6 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4328,35 +3889,6 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.7.1.tgz",
       "integrity": "sha512-k5pBjHDhmkdaUccnC7gE3mBzZjcxyxYsYVaqiL2G5AqlfLyBO5nw2VdNK+O16cveEPd/gIOWULH7gkiYYwVNHg==",
       "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "body-parser": "1.18.1",
-        "chokidar": "1.7.0",
-        "colors": "1.1.2",
-        "combine-lists": "1.0.1",
-        "connect": "3.6.3",
-        "core-js": "2.5.1",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "expand-braces": "0.1.2",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "http-proxy": "1.16.2",
-        "isbinaryfile": "3.0.2",
-        "lodash": "3.10.1",
-        "log4js": "0.6.38",
-        "mime": "1.4.0",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.1.5",
-        "range-parser": "1.2.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "socket.io": "1.7.3",
-        "source-map": "0.5.7",
-        "tmp": "0.0.31",
-        "useragent": "2.2.1"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -4368,20 +3900,13 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         },
         "tmp": {
           "version": "0.0.31",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
           "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -4389,30 +3914,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz",
       "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
-      "dev": true,
-      "requires": {
-        "fs-access": "1.0.1",
-        "which": "1.3.0"
-      }
+      "dev": true
     },
     "karma-cli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/karma-cli/-/karma-cli-1.0.1.tgz",
       "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.4.0"
-      }
+      "dev": true
     },
     "karma-coverage-istanbul-reporter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-1.3.0.tgz",
       "integrity": "sha1-0ULNnFVzHJ42Pvc3To7xoxvr+ts=",
-      "dev": true,
-      "requires": {
-        "istanbul-api": "1.1.14",
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "karma-jasmine": {
       "version": "1.1.0",
@@ -4424,28 +3938,19 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.2.2.tgz",
       "integrity": "sha1-SKjl7xiAdhfuK14zwRlMNbQ5Ukw=",
-      "dev": true,
-      "requires": {
-        "karma-jasmine": "1.1.0"
-      }
+      "dev": true
     },
     "karma-source-map-support": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.2.0.tgz",
       "integrity": "sha1-G/gee7SwiWJ6s1LsQXnhF8QGpUA=",
-      "dev": true,
-      "requires": {
-        "source-map-support": "0.4.18"
-      }
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "0.2.7",
@@ -4457,37 +3962,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "dev": true
     },
     "less": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.5.5",
-        "mime": "1.4.0",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.81.0",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "less-loader": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-4.0.5.tgz",
       "integrity": "sha1-rhVadAbKxqzSk9eFWH/P8PR4xN0=",
       "dev": true,
-      "requires": {
-        "clone": "2.1.1",
-        "loader-utils": "1.1.0",
-        "pify": "2.3.0"
-      },
       "dependencies": {
         "clone": {
           "version": "2.1.1",
@@ -4497,27 +3984,11 @@
         }
       }
     },
-    "license-webpack-plugin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-0.5.1.tgz",
-      "integrity": "sha1-aNivEDSGqcTrzt237V071h84O+Q=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1"
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      }
+      "dev": true
     },
     "loader-runner": {
       "version": "2.3.0",
@@ -4529,22 +4000,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
-      }
+      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -4609,10 +4071,6 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
-      "requires": {
-        "readable-stream": "1.0.34",
-        "semver": "4.3.6"
-      },
       "dependencies": {
         "semver": {
           "version": "4.3.6",
@@ -4621,6 +4079,12 @@
           "dev": true
         }
       }
+    },
+    "loglevel": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz",
+      "integrity": "sha512-OQ2jhWI5G2qsvO0UFNyCQWgKl/tFiwuPIXxELzACeUO2FqstN/R7mmL09+nhv6xOWVPPojQO1A90sCEoJSgBcQ==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -4632,20 +4096,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4657,11 +4114,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "dev": true
     },
     "macaddress": {
       "version": "0.2.8",
@@ -4673,10 +4126,7 @@
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
       "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
-      "dev": true,
-      "requires": {
-        "vlq": "0.2.2"
-      }
+      "dev": true
     },
     "make-error": {
       "version": "1.3.0",
@@ -4690,19 +4140,16 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
-    "matcher-collection": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "dev": true,
-      "requires": {
-        "minimatch": "3.0.4"
-      }
-    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true
     },
     "md5.js": {
@@ -4710,20 +4157,12 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
-      "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
-      },
       "dependencies": {
         "hash-base": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -4737,20 +4176,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "dev": true
     },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4762,25 +4194,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -4789,18 +4209,6 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -4826,32 +4234,13 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      }
+      "dev": true
     },
     "miller-rabin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
-      }
+      "dev": true
     },
     "mime": {
       "version": "1.4.0",
@@ -4869,10 +4258,7 @@
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.30.0"
-      }
+      "dev": true
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -4896,10 +4282,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "0.0.8",
@@ -4912,10 +4295,6 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
-      "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
-      },
       "dependencies": {
         "for-in": {
           "version": "0.1.8",
@@ -4929,10 +4308,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -4944,22 +4320,12 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
       "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
-      "dev": true,
-      "requires": {
-        "dns-packet": "1.2.2",
-        "thunky": "0.1.0"
-      }
+      "dev": true
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nan": {
@@ -4973,10 +4339,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true,
-      "requires": {
-        "xml-char-classes": "1.0.0"
-      }
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4988,10 +4351,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "dev": true
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true
     },
     "node-forge": {
       "version": "0.6.33",
@@ -5005,31 +4371,13 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
-      },
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0"
-          }
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -5045,31 +4393,6 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.4",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -5082,24 +4405,12 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "string_decoder": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "dev": true
             }
           }
         }
@@ -5117,40 +4428,13 @@
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.7.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "optional": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -5165,32 +4449,19 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.0",
-        "osenv": "0.1.4"
-      }
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -5202,43 +4473,25 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
-      }
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "2.0.1"
-      }
+      "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
+      "dev": true
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0"
-      }
+      "dev": true
     },
     "null-check": {
       "version": "1.0.0",
@@ -5281,19 +4534,12 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      },
       "dependencies": {
         "for-own": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -5307,10 +4553,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
+      "dev": true
     },
     "on-headers": {
       "version": "1.0.1",
@@ -5322,37 +4565,19 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "dev": true
     },
     "opn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
       "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "1.1.0"
-      }
+      "dev": true
     },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "0.0.3"
-      }
+      "dev": true
     },
     "options": {
       "version": "0.0.6",
@@ -5365,19 +4590,12 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
-      "requires": {
-        "url-parse": "1.0.5"
-      },
       "dependencies": {
         "url-parse": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "dev": true,
-          "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -5398,9 +4616,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "optional": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -5412,11 +4628,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5434,10 +4646,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.1.0"
-      }
+      "dev": true
     },
     "p-map": {
       "version": "1.2.0",
@@ -5455,71 +4664,43 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
-      "requires": {
-        "no-case": "2.3.2"
-      }
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true,
-      "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.8",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
-      }
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "dev": true
     },
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.2",
@@ -5537,10 +4718,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5576,25 +4754,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-      "dev": true,
-      "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
@@ -5618,21 +4784,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.8",
-        "mkdirp": "0.5.1"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -5647,25 +4805,12 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.3.2",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
           "dependencies": {
             "supports-color": {
               "version": "2.0.0",
@@ -5681,166 +4826,97 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
-      }
+      "dev": true
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true,
-      "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqid": "4.1.1"
-      }
+      "dev": true
     },
     "postcss-load-config": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
-      }
+      "dev": true
     },
     "postcss-load-options": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "postcss-load-plugins": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "postcss-loader": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
       "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-load-config": "1.2.0"
-      }
+      "dev": true
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
@@ -5852,55 +4928,31 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3"
-      }
+      "dev": true
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
-      "requires": {
-        "postcss": "6.0.11"
-      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -5912,21 +4964,13 @@
           "version": "6.0.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -5935,10 +4979,6 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.11"
-      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -5950,21 +4990,13 @@
           "version": "6.0.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -5973,10 +5005,6 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.11"
-      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -5988,21 +5016,13 @@
           "version": "6.0.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6011,10 +5031,6 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
-      "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.11"
-      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -6026,21 +5042,13 @@
           "version": "6.0.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6048,111 +5056,61 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true,
-      "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true,
-      "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true,
-      "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
-      }
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-url": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-5.1.2.tgz",
       "integrity": "sha1-mLMWW+jVkkccsMqt3iwNH4MvEz4=",
-      "dev": true,
-      "requires": {
-        "directory-encoder": "0.7.2",
-        "js-base64": "2.3.2",
-        "mime": "1.4.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-is-absolute": "1.0.1",
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -6164,12 +5122,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -6187,11 +5140,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true,
-      "requires": {
-        "renderkid": "2.0.1",
-        "utila": "0.4.0"
-      }
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -6210,85 +5159,37 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "asap": "2.0.6"
-      }
+      "optional": true
     },
     "protractor": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.1.2.tgz",
       "integrity": "sha1-myIXQXCaTGLVzVPGqt1UpxE36V8=",
       "dev": true,
-      "requires": {
-        "@types/node": "6.0.88",
-        "@types/q": "0.0.32",
-        "@types/selenium-webdriver": "2.53.42",
-        "blocking-proxy": "0.0.5",
-        "chalk": "1.1.3",
-        "glob": "7.1.2",
-        "jasmine": "2.8.0",
-        "jasminewd2": "2.1.0",
-        "optimist": "0.6.1",
-        "q": "1.4.1",
-        "saucelabs": "1.3.0",
-        "selenium-webdriver": "3.0.1",
-        "source-map-support": "0.4.18",
-        "webdriver-js-extender": "1.0.0",
-        "webdriver-manager": "12.0.6"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "del": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         },
         "globby": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         },
         "q": {
           "version": "1.4.1",
@@ -6307,19 +5208,6 @@
           "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
           "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
           "dev": true,
-          "requires": {
-            "adm-zip": "0.4.7",
-            "chalk": "1.1.3",
-            "del": "2.2.2",
-            "glob": "7.1.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "q": "1.4.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.2",
-            "semver": "5.4.1",
-            "xml2js": "0.4.19"
-          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -6335,11 +5223,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
-      "dev": true,
-      "requires": {
-        "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
-      }
+      "dev": true
     },
     "prr": {
       "version": "0.0.0",
@@ -6357,14 +5241,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -6394,11 +5271,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -6423,28 +5296,18 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
+              "dev": true
             }
           }
         },
@@ -6452,10 +5315,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+          "dev": true
         }
       }
     },
@@ -6463,10 +5323,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
@@ -6479,12 +5336,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "unpipe": "1.0.0"
-      },
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
@@ -6504,46 +5355,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      }
+      "dev": true
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
+      "dev": true
     },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
+      "dev": true
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6555,25 +5385,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -6581,31 +5399,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "dev": true
     },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
-      }
+      "dev": true
     },
     "reduce-function-call": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2"
-      }
+      "dev": true
     },
     "reflect-metadata": {
       "version": "0.1.10",
@@ -6629,21 +5435,13 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
+      "dev": true
     },
     "regexpu-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "dev": true
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -6655,10 +5453,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      }
+      "dev": true
     },
     "relateurl": {
       "version": "0.2.7",
@@ -6677,13 +5472,6 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.1.4",
-        "htmlparser2": "3.3.0",
-        "strip-ansi": "3.0.1",
-        "utila": "0.3.3"
-      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -6709,40 +5497,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "dev": true
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      }
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -6772,86 +5533,30 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
-      "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
-      }
-    },
-    "rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
       "dev": true
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
     },
     "rxjs": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
-      "requires": {
-        "symbol-observable": "1.0.4"
-      }
+      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -6864,26 +5569,13 @@
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
-      }
+      "optional": true
     },
     "sass-loader": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
       "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
       "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "clone-deep": "0.3.0",
-        "loader-utils": "1.1.0",
-        "lodash.tail": "4.1.1",
-        "pify": "3.0.0"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
@@ -6897,10 +5589,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
       "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "1.0.0"
-      }
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -6912,19 +5601,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.2.2"
-      }
-    },
-    "script-loader": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.1.tgz",
-      "integrity": "sha512-upPXlUIIRY1o1ba8w8nOLm3ZEndtpczyPmA3HJ4ZdktyMNct3wxj3VTl+0/PENtYSKJdzdVhWrLiHhBIEOiFqg==",
-      "dev": true,
-      "requires": {
-        "raw-loader": "0.5.1"
-      }
+      "dev": true
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -6932,20 +5609,13 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "js-base64": "2.3.2",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -6960,21 +5630,12 @@
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.0.1.tgz",
       "integrity": "sha1-ot6l2kqX9mcuiefKcnbO+jZRR6c=",
       "dev": true,
-      "requires": {
-        "adm-zip": "0.4.7",
-        "rimraf": "2.6.2",
-        "tmp": "0.0.30",
-        "xml2js": "0.4.19"
-      },
       "dependencies": {
         "tmp": {
           "version": "0.0.30",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -6982,10 +5643,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
       "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
-      "dev": true,
-      "requires": {
-        "node-forge": "0.6.33"
-      }
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
@@ -6997,31 +5655,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
       "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
-      "dev": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
+      "dev": true
     },
     "send": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
       "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.2",
-        "mime": "1.3.4",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
       "dependencies": {
         "mime": {
           "version": "1.3.4",
@@ -7035,28 +5675,13 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
       "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "batch": "0.6.1",
-        "debug": "2.6.8",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
-        "parseurl": "1.3.2"
-      }
+      "dev": true
     },
     "serve-static": {
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
       "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.15.4"
-      }
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -7086,31 +5711,19 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "shallow-clone": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "dev": true,
-      "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
-      },
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+          "dev": true
         }
       }
     },
@@ -7118,10 +5731,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -7139,43 +5749,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8"
-      }
+      "dev": true
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "socket.io": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
       "integrity": "sha1-uK+cq6AJSeVo42nxMn6pvp6iRhs=",
       "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.3",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.7.3",
-        "socket.io-parser": "2.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -7196,19 +5788,12 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "socket.io-parser": "2.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -7223,19 +5808,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
       "integrity": "sha1-sw6GqhDV7zVGYBwJzeR2Xjgdo3c=",
       "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.3",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
-      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -7247,10 +5819,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -7265,21 +5834,12 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
-      "requires": {
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -7294,10 +5854,6 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
       "dev": true,
-      "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "2.0.3"
-      },
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
@@ -7307,39 +5863,11 @@
         }
       }
     },
-    "sockjs-client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
-      "integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.1.9"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": "0.7.0"
-          }
-        }
-      }
-    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",
@@ -7358,11 +5886,6 @@
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.1.tgz",
       "integrity": "sha1-SBJr6SML1H+tBeRqjDwuPS2r5Qc=",
       "dev": true,
-      "requires": {
-        "async": "0.9.2",
-        "loader-utils": "0.2.17",
-        "source-map": "0.1.43"
-      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -7374,22 +5897,13 @@
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -7397,19 +5911,13 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -7427,30 +5935,13 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
-      }
+      "dev": true
     },
     "spdy-transport": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7462,25 +5953,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -7495,16 +5974,6 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -7526,9 +5995,6 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7542,26 +6008,14 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "optional": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "optional": true
         }
       }
     },
@@ -7570,10 +6024,6 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7585,25 +6035,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -7612,13 +6050,6 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
-      "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7630,25 +6061,13 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -7669,10 +6088,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -7684,10 +6099,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -7701,19 +6113,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -7725,10 +6131,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -7740,38 +6143,19 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0"
-      }
+      "dev": true
     },
     "stylus": {
       "version": "0.54.5",
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
-      "requires": {
-        "css-parse": "1.7.0",
-        "debug": "2.6.8",
-        "glob": "7.0.6",
-        "mkdirp": "0.5.1",
-        "sax": "0.5.8",
-        "source-map": "0.1.43"
-      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "sax": {
           "version": "0.5.8",
@@ -7783,10 +6167,7 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -7794,36 +6175,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.1.tgz",
       "integrity": "sha1-d/SzT9Aw0lsmF7z1UT21sHMMQIk=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "lodash.clonedeep": "4.5.0",
-        "when": "3.6.4"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "dev": true,
-      "requires": {
-        "has-flag": "1.0.0"
-      }
+      "dev": true
     },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-      "dev": true,
-      "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
-      }
+      "dev": true
     },
     "symbol-observable": {
       "version": "1.0.4",
@@ -7841,30 +6205,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
-    },
-    "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
-      }
+      "optional": true
     },
     "through": {
       "version": "2.3.8",
@@ -7888,19 +6229,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
-      "dev": true,
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "to-array": {
       "version": "0.1.4",
@@ -7930,10 +6265,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -7952,18 +6284,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.2.2.tgz",
       "integrity": "sha1-u9KOOK9Kqj6WB2xGbhsiAZfBo84=",
       "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.1.0",
-        "diff": "3.3.1",
-        "make-error": "1.3.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18",
-        "tsconfig": "6.0.0",
-        "v8flags": "3.0.0",
-        "yn": "2.0.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -7978,10 +6298,6 @@
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
       "dev": true,
-      "requires": {
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
-      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -7996,12 +6312,6 @@
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
       "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
       "dev": true,
-      "requires": {
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map": "0.5.7",
-        "source-map-support": "0.4.18"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -8021,27 +6331,12 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.3.2.tgz",
       "integrity": "sha1-5WRZ+wlacwfxA7hAUhdPXju+9u0=",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
-        "diff": "3.3.1",
-        "glob": "7.1.2",
-        "optimist": "0.6.1",
-        "resolve": "1.4.0",
-        "semver": "5.4.1",
-        "tslib": "1.7.1",
-        "tsutils": "2.8.2"
-      },
       "dependencies": {
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         }
       }
     },
@@ -8049,10 +6344,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.2.tgz",
       "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -8064,10 +6356,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -8080,11 +6369,7 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
-      }
+      "dev": true
     },
     "typescript": {
       "version": "2.3.4",
@@ -8096,11 +6381,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.1.tgz",
       "integrity": "sha512-f7DpmEgt/RYAKzQzcfahn3JYZHobDwTZCa8oixC7pweVGEIizTX2kTYdNWcdk00xsMJqUhI8RDAa9HXHXGhNxA==",
-      "dev": true,
-      "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -8114,11 +6395,6 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "dev": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.0.1"
-      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -8130,23 +6406,13 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          }
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -8158,13 +6424,7 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+          "dev": true
         }
       }
     },
@@ -8184,10 +6444,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
+      "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
@@ -8218,10 +6475,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -8231,33 +6484,11 @@
         }
       }
     },
-    "url-loader": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "1.3.6"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-          "dev": true
-        }
-      }
-    },
     "url-parse": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
       "dev": true,
-      "requires": {
-        "querystringify": "1.0.0",
-        "requires-port": "1.0.0"
-      },
       "dependencies": {
         "querystringify": {
           "version": "1.0.0",
@@ -8278,10 +6509,6 @@
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
-      "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.33"
-      },
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
@@ -8296,9 +6523,6 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -8336,20 +6560,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
       "integrity": "sha512-AGl+C+4qpeSu2g3JxCD/mGFFOs/vVZ3XREkD3ibQXEqr4Y4zgIrPWW124/IKJFHOIVFIoH8miWrLf0o84HYjwA==",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "dev": true
     },
     "vary": {
       "version": "1.1.1",
@@ -8368,11 +6585,6 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -8392,10 +6604,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "dev": true
     },
     "void-elements": {
       "version": "2.0.1",
@@ -8403,45 +6612,23 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
-    "walk-sync": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "dev": true,
-      "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.5"
-      }
-    },
     "watchpack": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "wbuf": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "webdriver-js-extender": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-1.0.0.tgz",
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
-      "requires": {
-        "@types/selenium-webdriver": "2.53.42",
-        "selenium-webdriver": "2.53.3"
-      },
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
@@ -8459,14 +6646,7 @@
           "version": "2.53.3",
           "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
           "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
-          "dev": true,
-          "requires": {
-            "adm-zip": "0.4.4",
-            "rimraf": "2.6.2",
-            "tmp": "0.0.24",
-            "ws": "1.1.2",
-            "xml2js": "0.4.4"
-          }
+          "dev": true
         },
         "tmp": {
           "version": "0.0.24",
@@ -8478,43 +6658,15 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
           "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
-          "dev": true,
-          "requires": {
-            "sax": "0.6.1",
-            "xmlbuilder": "9.0.4"
-          }
+          "dev": true
         }
       }
     },
     "webpack": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.4.1.tgz",
-      "integrity": "sha1-TD9PP7MYFVpNsMtqNv8FxWl0GPQ=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.6.0.tgz",
+      "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
       "dev": true,
-      "requires": {
-        "acorn": "5.1.2",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.2",
-        "ajv-keywords": "2.1.0",
-        "async": "2.5.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.0.4",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.4.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.0.1",
-        "yargs": "8.0.2"
-      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
@@ -8526,10 +6678,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
@@ -8541,54 +6690,31 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -8600,10 +6726,7 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         },
         "which-module": {
           "version": "2.0.0",
@@ -8615,31 +6738,51 @@
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          }
+          "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
+          "dev": true
+        }
+      }
+    },
+    "webpack-concat-plugin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-concat-plugin/-/webpack-concat-plugin-1.4.0.tgz",
+      "integrity": "sha512-Ym9Qm5Sw9oXJYChNJk09I/yaXDaV3UDxsa07wcCvILzIeSJTnSUZjhS4y2YkULzgE8VHOv9X04KtlJPZGwXqMg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true
         }
       }
     },
@@ -8647,140 +6790,25 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
       "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
-      "dev": true,
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.4.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
-      }
-    },
-    "webpack-dev-server": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.1.tgz",
-      "integrity": "sha1-oC5yaoe7YD211xq7fW0mSb8Qx2k=",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "bonjour": "3.5.0",
-        "chokidar": "1.7.0",
-        "compression": "1.7.0",
-        "connect-history-api-fallback": "1.3.0",
-        "del": "3.0.0",
-        "express": "4.15.4",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "internal-ip": "1.2.0",
-        "opn": "4.0.2",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.1",
-        "serve-index": "1.9.0",
-        "sockjs": "0.3.18",
-        "sockjs-client": "1.1.2",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "3.2.3",
-        "webpack-dev-middleware": "1.12.0",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          }
-        }
-      }
+      "dev": true
     },
     "webpack-merge": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.0.tgz",
       "integrity": "sha1-atciI7PguDflMeRZfBmfkJNhUR4=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
-      "dev": true,
-      "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true,
-      "requires": {
-        "http-parser-js": "0.4.6",
-        "websocket-extensions": "0.1.2"
-      }
+      "dev": true
     },
     "websocket-extensions": {
       "version": "0.1.2",
@@ -8804,45 +6832,32 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "dev": true
     },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -8863,30 +6878,18 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -8900,11 +6903,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
       "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
-      "dev": true,
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
+      "dev": true
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -8922,11 +6921,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
-      }
+      "dev": true
     },
     "xmlbuilder": {
       "version": "9.0.4",
@@ -8970,21 +6965,6 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -8998,22 +6978,14 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -9023,9 +6995,6 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -9049,9 +7018,9 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.17.tgz",
-      "integrity": "sha1-TF5RhahX2o2nk9rzkZNxxaNrKgs="
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
+      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,26 +13,26 @@
   "private": true,
   "dependencies": {
     "@agm/core": "^1.0.0-beta.1",
-    "@angular/animations": "^4.4.2",
-    "@angular/cdk": "^2.0.0-beta.10",
-    "@angular/common": "^4.2.4",
-    "@angular/compiler": "^4.2.4",
-    "@angular/core": "^4.2.4",
-    "@angular/forms": "^4.2.4",
-    "@angular/http": "^4.2.4",
-    "@angular/material": "^2.0.0-beta.10",
-    "@angular/platform-browser": "^4.2.4",
-    "@angular/platform-browser-dynamic": "^4.2.4",
-    "@angular/router": "^4.2.4",
+    "@angular/animations": "^4.4.4",
+    "@angular/cdk": "^2.0.0-beta.12",
+    "@angular/common": "^4.4.4",
+    "@angular/compiler": "^4.4.4",
+    "@angular/core": "^4.4.4",
+    "@angular/forms": "^4.4.4",
+    "@angular/http": "^4.4.4",
+    "@angular/material": "^2.0.0-beta.12",
+    "@angular/platform-browser": "^4.4.4",
+    "@angular/platform-browser-dynamic": "^4.4.4",
+    "@angular/router": "^4.4.4",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "rxjs": "^5.4.2",
-    "zone.js": "^0.8.14"
+    "zone.js": "^0.8.18"
   },
   "devDependencies": {
-    "@angular/cli": "1.3.2",
-    "@angular/compiler-cli": "^4.2.4",
-    "@angular/language-service": "^4.2.4",
+    "@angular/cli": "^1.4.5",
+    "@angular/compiler-cli": "^4.4.4",
+    "@angular/language-service": "^4.4.4",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
@@ -48,6 +48,7 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.3.2",
-    "typescript": "~2.3.3"
+    "typescript": "~2.3.3",
+    "webpack": "^3.6.0"
   }
 }

--- a/src/app/admin/admin-toolbar/admin-toolbar.component.html
+++ b/src/app/admin/admin-toolbar/admin-toolbar.component.html
@@ -1,6 +1,6 @@
-<md-toolbar class='admin-toolbar'>
-  <button md-raised-button color="primary" [routerLink]="['/admin/organizations']">Organizations</button>
-  <button md-raised-button color="primary" [routerLink]="['/admin/organizations/new']">New Organization</button>
-  <button md-raised-button color="primary" [routerLink]="['/admin/projects']">Projects</button>
-  <button md-raised-button color="primary" [routerLink]="['/admin/projects/new']">New Project</button>
-</md-toolbar>
+<mat-toolbar class='admin-toolbar'>
+  <button mat-raised-button color="primary" [routerLink]="['/admin/organizations']">Organizations</button>
+  <button mat-raised-button color="primary" [routerLink]="['/admin/organizations/new']">New Organization</button>
+  <button mat-raised-button color="primary" [routerLink]="['/admin/projects']">Projects</button>
+  <button mat-raised-button color="primary" [routerLink]="['/admin/projects/new']">New Project</button>
+</mat-toolbar>

--- a/src/app/admin/admin-toolbar/admin-toolbar.component.spec.ts
+++ b/src/app/admin/admin-toolbar/admin-toolbar.component.spec.ts
@@ -32,7 +32,7 @@ describe('AdminToolbarComponent', () => {
 
   it('should render a material toolbar', () => {
     fixture.detectChanges();
-    de = fixture.debugElement.query(By.css('md-toolbar.mat-toolbar'));
+    de = fixture.debugElement.query(By.css('mat-toolbar.mat-toolbar'));
     //el = de.nativeElement;
     expect(de).toBeTruthy();
   });

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -1,11 +1,5 @@
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { OrganizationFormComponent } from './organization-form/organization-form.component';
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { HttpModule } from '@angular/http';
-import { MdInputModule, MdListModule, MdDatepickerModule, MdNativeDateModule, MdRadioModule, MdSelectModule } from '@angular/material';
 
 import { AdminRoutingModule } from './admin-routing.module';
 import { AdminComponent } from './admin.component';
@@ -22,31 +16,10 @@ import { ProjectFormComponent } from './project-form/project-form.component';
 
 @NgModule({
   imports: [
-    CommonModule,
-    HttpModule,
     AdminRoutingModule,
     SharedModule,
-    MdInputModule,
-    MdListModule,
-    FormsModule,
-    BrowserAnimationsModule,
-    BrowserModule,
-    ReactiveFormsModule,
-    MdNativeDateModule,
-    MdDatepickerModule,
-    MdRadioModule,
-    MdSelectModule
   ],
   exports: [
-    MdInputModule,
-    FormsModule,
-    BrowserAnimationsModule,
-    BrowserModule,
-    ReactiveFormsModule,
-    MdNativeDateModule,
-    MdDatepickerModule,
-    MdRadioModule,
-    MdSelectModule
   ],
   declarations: [
     AdminComponent,

--- a/src/app/admin/organization-form/organization-form.component.html
+++ b/src/app/admin/organization-form/organization-form.component.html
@@ -3,111 +3,111 @@
 <form class="organization-form">
   
     <!-- Field for the name of the organization-->
-    <md-form-field class="organization-name">
-      <input mdInput #orgName placeholder=" Organization Name " type="text" [formControl]="formControls.name">
-      <md-error *ngIf="formControls.name.hasError('required')">
+    <mat-form-field class="organization-name">
+      <input matInput #orgName placeholder=" Organization Name " type="text" [formControl]="formControls.name">
+      <mat-error *ngIf="formControls.name.hasError('required')">
         Name is <strong>required</strong>
-      </md-error>
-    </md-form-field>
+      </mat-error>
+    </mat-form-field>
   
     <!-- Field for the number of the organization limited with 6 character-->
-    <md-form-field class="organization-number">
-      <input mdInput #orgNumber maxlength="11" placeholder=" Organization Number " type="text" [formControl]="formControls.orgNumber">
-      <md-error *ngIf="formControls.orgNumber.hasError('required')">
+    <mat-form-field class="organization-number">
+      <input matInput #orgNumber maxlength="11" placeholder=" Organization Number " type="text" [formControl]="formControls.orgNumber">
+      <mat-error *ngIf="formControls.orgNumber.hasError('required')">
         The Organization number is <strong>required</strong>
-      </md-error>
-      <md-error *ngIf="formControls.orgNumber.hasError('pattern')">
+      </mat-error>
+      <mat-error *ngIf="formControls.orgNumber.hasError('pattern')">
         The Organization number must be written in this format <strong>XXXXXX-XXXX</strong>
-      </md-error>
-      <md-hint align="end">{{orgNumber.value.length}} / 11</md-hint>
-    </md-form-field>
+      </mat-error>
+      <mat-hint align="end">{{orgNumber.value.length}} / 11</mat-hint>
+    </mat-form-field>
   
     <!-- Field for the information of the contact person in the organization-->
     <table class="organization-contact" cellspacing="0">
       <tr>
         <td>
-          <md-form-field class="organization-contact-name">
-            <input mdInput #contactName placeholder=" Contact name " type="text" [formControl]="formControls.contact">
-            <md-error *ngIf="formControls.contact.hasError('required')">
+          <mat-form-field class="organization-contact-name">
+            <input matInput #contactName placeholder=" Contact name " type="text" [formControl]="formControls.contact">
+            <mat-error *ngIf="formControls.contact.hasError('required')">
               Contact Name is <strong>required</strong>
-            </md-error>
-          </md-form-field>
+            </mat-error>
+          </mat-form-field>
         </td>
         <td>
-          <md-form-field class="organization-contact-email">
-            <input mdInput placeholder=" Contact Email " [formControl]="formControls.contactEmail">
-            <md-error *ngIf="formControls.contactEmail.hasError('pattern')">
+          <mat-form-field class="organization-contact-email">
+            <input matInput placeholder=" Contact Email " [formControl]="formControls.contactEmail">
+            <mat-error *ngIf="formControls.contactEmail.hasError('pattern')">
               Please enter a valid email address
-            </md-error>
-            <md-error *ngIf="formControls.contactEmail.hasError('required')">
+            </mat-error>
+            <mat-error *ngIf="formControls.contactEmail.hasError('required')">
               Email is <strong>required</strong>
-            </md-error>
-          </md-form-field>
+            </mat-error>
+          </mat-form-field>
         </td>
       </tr>
     </table>
   
     <!-- Field for the  street Adress of the organization-->
-    <md-form-field class="organization-address">
-      <textarea mdInput #orgAdress placeholder=" Address " type="text" [formControl]="formControls.adress"></textarea>
-      <md-error *ngIf="formControls.adress.hasError('required')">
+    <mat-form-field class="organization-address">
+      <textarea matInput #orgAdress placeholder=" Address " type="text" [formControl]="formControls.adress"></textarea>
+      <mat-error *ngIf="formControls.adress.hasError('required')">
         Address is <strong>required</strong>
-      </md-error>
-    </md-form-field>
+      </mat-error>
+    </mat-form-field>
   
     <!-- Field for the city,postcode of the organization-->
     <table class="organization-location" cellspacing="0">
       <tr>
         <td>
-          <md-form-field class="organization-postalCode">
-            <input mdInput #postalCode maxlength="5" placeholder=" Postal Code " value="" type="number" [formControl]="formControls.zipCode">
-            <md-error *ngIf="formControls.zipCode.hasError('required')">
+          <mat-form-field class="organization-postalCode">
+            <input matInput #postalCode maxlength="5" placeholder=" Postal Code " value="" type="number" [formControl]="formControls.zipCode">
+            <mat-error *ngIf="formControls.zipCode.hasError('required')">
               the post code is <strong>required</strong>
-            </md-error>
-            <md-error *ngIf="formControls.zipCode.hasError('pattern')">
+            </mat-error>
+            <mat-error *ngIf="formControls.zipCode.hasError('pattern')">
               the post code is <strong>5 digits</strong>
-            </md-error>
-            <md-hint align="end">{{postalCode.value.length}} / 5</md-hint>
-          </md-form-field>
+            </mat-error>
+            <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>
+          </mat-form-field>
         </td>
         <td>
-          <md-form-field class="organization-city" type="text" required>
-            <input mdInput #orgCity placeholder=" City " type="text" [formControl]="formControls.city">
-            <md-error *ngIf="formControls.city.hasError('required')">
+          <mat-form-field class="organization-city" type="text" required>
+            <input matInput #orgCity placeholder=" City " type="text" [formControl]="formControls.city">
+            <mat-error *ngIf="formControls.city.hasError('required')">
               The city where the organisation is locate is <strong>required</strong>
-            </md-error>
-          </md-form-field>
+            </mat-error>
+          </mat-form-field>
         </td>
       </tr>
     </table>
   
     <!--Field to save the description of the organisation-->
-    <md-form-field class="organization-description">
-      <textarea mdInput #orgDesc maxlength="200" placeholder=" Description " type="text" [formControl]="formControls.description"></textarea>
-      <md-error *ngIf="formControls.description.hasError('required')">
+    <mat-form-field class="organization-description">
+      <textarea matInput #orgDesc maxlength="200" placeholder=" Description " type="text" [formControl]="formControls.description"></textarea>
+      <mat-error *ngIf="formControls.description.hasError('required')">
         The description of the organisation is <strong>required</strong>
-      </md-error>
-      <md-hint align="end">{{orgDesc.value.length}} / 200</md-hint>
-    </md-form-field>
+      </mat-error>
+      <mat-hint align="end">{{orgDesc.value.length}} / 200</mat-hint>
+    </mat-form-field>
   
     <!--Field for the password-->
-    <!-- <md-form-field class="organization-password">
-      <input mdInput #orgPassword placeholder=" Password " type="password" [formControl]="formControls.password">
-      <md-error *ngIf="formControls.password.hasError('required')">
+    <!-- <mat-form-field class="organization-password">
+      <input matInput #orgPassword placeholder=" Password " type="password" [formControl]="formControls.password">
+      <mat-error *ngIf="formControls.password.hasError('required')">
         Password is <strong>required!</strong>
-      </md-error> -->
-      <!-- <md-error *ngIf="formControls.password.hasError('mismatch-password')">
+      </mat-error> -->
+      <!-- <mat-error *ngIf="formControls.password.hasError('mismatch-password')">
         Password(s) are <strong>mismatched!</strong>
-      </md-error> -->
-    <!-- </md-form-field> -->
+      </mat-error> -->
+    <!-- </mat-form-field> -->
   
     <!--Field for the comfirmation of the password-->
-    <!-- <md-form-field class="organization-repeatPassword">
-      <input mdInput #orgPasswordrepeat placeholder=" Confirm Password " type="password" [formControl]="formControls.repeatPassword">
-      <md-error *ngIf="formControls.repeatPassword.hasError('mismatch-repeat')">
+    <!-- <mat-form-field class="organization-repeatPassword">
+      <input matInput #orgPasswordrepeat placeholder=" Confirm Password " type="password" [formControl]="formControls.repeatPassword">
+      <mat-error *ngIf="formControls.repeatPassword.hasError('mismatch-repeat')">
         Password(s) are <strong>mismatched!</strong>
-      </md-error>
-    </md-form-field> -->
+      </mat-error>
+    </mat-form-field> -->
   
     <!-- <div [formGroup]="orgFormPasswords">
       <div formGroupName="passwords">
@@ -126,6 +126,6 @@
     </div> -->
   
     <!--Button to save the form or Canceled-->
-    <button md-raised-button color="warn">Cancel</button>
-    <button md-raised-button color="primary">Validate</button>
+    <button mat-raised-button color="warn">Cancel</button>
+    <button mat-raised-button color="primary">Validate</button>
   </form>

--- a/src/app/admin/organization-form/organization-form.component.spec.ts
+++ b/src/app/admin/organization-form/organization-form.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { OrganizationFormComponent } from './organization-form.component';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DataService } from '../services/data.service';
 import { SharedModule } from '../../shared/shared.module';
 
@@ -12,7 +11,7 @@ describe('OrganizationFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ OrganizationFormComponent ],
-      imports: [ SharedModule, FormsModule, ReactiveFormsModule ],
+      imports: [ SharedModule],
     })
     .compileComponents();
   }));

--- a/src/app/admin/organization-list/organization-list.component.ts
+++ b/src/app/admin/organization-list/organization-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { DataService } from '../services/data.service';
 import { DataSource } from '@angular/cdk/collections';
-import { MdPaginator } from '@angular/material';
+import { MatPaginator } from '@angular/material';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/startWith';

--- a/src/app/admin/organization-page/organization-page.component.html
+++ b/src/app/admin/organization-page/organization-page.component.html
@@ -1,19 +1,19 @@
 <div *ngIf="organization">
     <h2 class="org-title">{{organization.name}}</h2>
-    <md-list>
-      <md-list-item class="org-name"><div md-line><div class="label">Name: </div><div class="org-name">{{organization.name}}</div></div></md-list-item>
-      <md-list-item class="org-id"><div md-line><div class="label">ID: </div><div class="org-id">{{organization.orgId}}</div></div></md-list-item>
-      <md-list-item class="org-address"><div md-line><div class="label">Address: </div><div class="org-address">{{organization.address}}</div></div></md-list-item>
-      <md-list-item class="org-billing"><div md-line><div class="label">Billing: </div><div class="org-billing">{{organization.billing}}</div></div></md-list-item>
-      <md-divider></md-divider>
-      <md-list-item class="org-person"><div md-line><div class="label">Contact Name: </div><div class="org-person">{{organization.contact.person}}</div></div></md-list-item>
-      <md-list-item class="org-email"><div md-line><div class="label">Contact Email: </div><div class="org-email">{{organization.contact.email}}</div></div></md-list-item>
-      <md-list-item class="org-phone"><div md-line><div class="label">Contact Phone: </div><div class="org-phone">{{organization.contact.phone}}</div></div></md-list-item>
-      <md-divider></md-divider>
-    </md-list>
+    <mat-list>
+      <mat-list-item class="org-name"><div mat-line><div class="label">Name: </div><div class="org-name">{{organization.name}}</div></div></mat-list-item>
+      <mat-list-item class="org-id"><div mat-line><div class="label">ID: </div><div class="org-id">{{organization.orgId}}</div></div></mat-list-item>
+      <mat-list-item class="org-address"><div mat-line><div class="label">Address: </div><div class="org-address">{{organization.address}}</div></div></mat-list-item>
+      <mat-list-item class="org-billing"><div mat-line><div class="label">Billing: </div><div class="org-billing">{{organization.billing}}</div></div></mat-list-item>
+      <mat-divider></mat-divider>
+      <mat-list-item class="org-person"><div mat-line><div class="label">Contact Name: </div><div class="org-person">{{organization.contact.person}}</div></div></mat-list-item>
+      <mat-list-item class="org-email"><div mat-line><div class="label">Contact Email: </div><div class="org-email">{{organization.contact.email}}</div></div></mat-list-item>
+      <mat-list-item class="org-phone"><div mat-line><div class="label">Contact Phone: </div><div class="org-phone">{{organization.contact.phone}}</div></div></mat-list-item>
+      <mat-divider></mat-divider>
+    </mat-list>
     
     <div class="project-list">
-      <div md-line>
+      <div mat-line>
         <h4>Projects of {{organization.name}}</h4>
         <ul class="project-list">
             <li *ngFor="let project of organization.projects">

--- a/src/app/admin/project-form/project-form.component.html
+++ b/src/app/admin/project-form/project-form.component.html
@@ -9,142 +9,142 @@
   </div>
 
   <!-- FIELD: PROJECT NAME -->
-  <md-form-field class='project-full-width'>
-    <input mdInput #name name='NAME' placeholder='{{attributes.NAME.placeholder}}' [formControl]='projectControls.name'>
-    <md-error *ngIf='projectControls.name.hasError("required")'>Name is<strong>required</strong></md-error>
-  </md-form-field>
+  <mat-form-field class='project-full-width'>
+    <input matInput #name name='NAME' placeholder='{{attributes.NAME.placeholder}}' [formControl]='projectControls.name'>
+    <mat-error *ngIf='projectControls.name.hasError("required")'>Name is<strong>required</strong></mat-error>
+  </mat-form-field>
 
   <!-- FIELD: PROJECT NUMBER ID -->
-  <md-form-field class='project-full-width'>
-    <input mdInput #projectId name='PROJECT_ID' placeholder='{{attributes.PROJECT_ID.placeholder}}' [formControl]='projectControls.projectId'>
-    <md-error *ngIf='projectControls.projectId.hasError("required")'>Project number is<strong>required</strong></md-error>
-    <md-error *ngIf='projectControls.projectId.hasError("pattern")'>Project number must be written in this format<strong>XXXXXX-XXXX</strong></md-error>
-  </md-form-field>
+  <mat-form-field class='project-full-width'>
+    <input matInput #projectId name='PROJECT_ID' placeholder='{{attributes.PROJECT_ID.placeholder}}' [formControl]='projectControls.projectId'>
+    <mat-error *ngIf='projectControls.projectId.hasError("required")'>Project number is<strong>required</strong></mat-error>
+    <mat-error *ngIf='projectControls.projectId.hasError("pattern")'>Project number must be written in this format<strong>XXXXXX-XXXX</strong></mat-error>
+  </mat-form-field>
 
   <!-- FIELD: PROJECT MANAGER -->
-  <md-form-field class='project-full-width'>
-    <input mdInput #manager name='MANAGER' placeholder='{{attributes.MANAGER.placeholder}}' [formControl]='projectControls.manager'>
-    <md-error *ngIf='projectControls.manager.hasError("required")'>Project manager is<strong>required</strong></md-error>
-    <md-error *ngIf='projectControls.manager.hasError("pattern")'>Must be<strong>valid</strong> name!</md-error>
-  </md-form-field>
+  <mat-form-field class='project-full-width'>
+    <input matInput #manager name='MANAGER' placeholder='{{attributes.MANAGER.placeholder}}' [formControl]='projectControls.manager'>
+    <mat-error *ngIf='projectControls.manager.hasError("required")'>Project manager is<strong>required</strong></mat-error>
+    <mat-error *ngIf='projectControls.manager.hasError("pattern")'>Must be<strong>valid</strong> name!</mat-error>
+  </mat-form-field>
 
   <!-- FIELD: PROJECT ADDRESS -->
-  <md-form-field class='project-full-width'>
-    <input mdInput #address name='ADDRESS' placeholder='{{attributes.ADDRESS.placeholder}}' [formControl]='projectControls.address'>
-    <md-error *ngIf='projectControls.address.hasError("required")'>
+  <mat-form-field class='project-full-width'>
+    <input matInput #address name='ADDRESS' placeholder='{{attributes.ADDRESS.placeholder}}' [formControl]='projectControls.address'>
+    <mat-error *ngIf='projectControls.address.hasError("required")'>
       Address is
       <strong>required</strong>
-    </md-error>
-  </md-form-field>
+    </mat-error>
+  </mat-form-field>
 
   <!-- FIELDS: PROJECT LIFECYCLE -->
   <table class='project-full-width' cellspacing='0'>
     <tr>
       <td>
-        <md-form-field>
-          <input name='FROM_DATE' mdInput [mdDatepicker]='myDatepicker' placeholder='From (date)' [formControl]='projectControls.fromDate'>
-          <md-error *ngIf='projectControls.fromDate.hasError("required")'>
+        <mat-form-field>
+          <input name='FROM_DATE' matInput [matDatepicker]='myDatepicker' placeholder='From (date)' [formControl]='projectControls.fromDate'>
+          <mat-error *ngIf='projectControls.fromDate.hasError("required")'>
             The starting Date is
             <strong>required</strong>
-          </md-error>
-          <md-datepicker-toggle mdSuffix [for]='myDatepicker'></md-datepicker-toggle>
-          <md-datepicker #myDatepicker></md-datepicker>
-        </md-form-field>
+          </mat-error>
+          <mat-datepicker-toggle mdSuffix [for]='myDatepicker'></mat-datepicker-toggle>
+          <mat-datepicker #myDatepicker></mat-datepicker>
+        </mat-form-field>
       </td>
       <td>
-        <md-form-field>
-          <input name='TO_DATE' mdInput [mdDatepicker]='myDatepicker2' placeholder='To (date)' [formControl]='projectControls.toDate'>
-          <md-error *ngIf='projectControls.toDate.hasError("required")'>
+        <mat-form-field>
+          <input name='TO_DATE' matInput [matDatepicker]='myDatepicker2' placeholder='To (date)' [formControl]='projectControls.toDate'>
+          <mat-error *ngIf='projectControls.toDate.hasError("required")'>
             The ending Date is
             <strong>required</strong>
-          </md-error>
-          <md-error *ngIf='projectControls.toDate.hasError("wrongdate") || projectControls.toDate.hasError("impossibleDate")'>
+          </mat-error>
+          <mat-error *ngIf='projectControls.toDate.hasError("wrongdate") || projectControls.toDate.hasError("impossibleDate")'>
             The ending Date must not be <strong>before start </strong>
-          </md-error>
-          <md-datepicker-toggle mdSuffix [for]='myDatepicker2'></md-datepicker-toggle>
-          <md-datepicker #myDatepicker2></md-datepicker>
-        </md-form-field>
+          </mat-error>
+          <mat-datepicker-toggle mdSuffix [for]='myDatepicker2'></mat-datepicker-toggle>
+          <mat-datepicker #myDatepicker2></mat-datepicker>
+        </mat-form-field>
       </td>
     </tr>
   </table>
 
   <!-- FIELD: PROJECT GOAL AMOUNT -->
-  <md-form-field class='project-full-width'>
-    <input mdInput name='GOAL' placeholder='{{attributes.GOAL.placeholder}}' [formControl]='projectControls.goal'>
-    <md-error *ngIf='projectControls.goal.hasError("required")'>
+  <mat-form-field class='project-full-width'>
+    <input matInput name='GOAL' placeholder='{{attributes.GOAL.placeholder}}' [formControl]='projectControls.goal'>
+    <mat-error *ngIf='projectControls.goal.hasError("required")'>
       The goal is
       <strong>required</strong>
-    </md-error>
-  </md-form-field>
+    </mat-error>
+  </mat-form-field>
 
   <!-- Field for the city,postcode and country of the project
     <table class='project-full-width' cellspacing='0'>
       <tr>
         <td>
-          <md-form-field class='project-full-width'>
-            <input mdInput #postalCode maxlength='5' placeholder=' Postal Code ' value='' type='number' [formControl]='projectControls.zipCode'>
-            <md-error *ngIf='projectControls.zipCode.hasError('required')'>
+          <mat-form-field class='project-full-width'>
+            <input matInput #postalCode maxlength='5' placeholder=' Postal Code ' value='' type='number' [formControl]='projectControls.zipCode'>
+            <mat-error *ngIf='projectControls.zipCode.hasError('required')'>
               the ppstCode is <strong>required</strong>
-            </md-error>
-            <md-hint align='end'>{{postalCode.value.length}} / 5</md-hint>
-          </md-form-field>
+            </mat-error>
+            <mat-hint align='end'>{{postalCode.value.length}} / 5</mat-hint>
+          </mat-form-field>
         </td>
         <td>
-          <md-form-field class='project-full-width'  required>
-            <input mdInput #orgCity placeholder=' City '  [formControl]='projectControls.city'>
-            <md-error *ngIf='projectControls.city.hasError('required')'>
+          <mat-form-field class='project-full-width'  required>
+            <input matInput #orgCity placeholder=' City '  [formControl]='projectControls.city'>
+            <mat-error *ngIf='projectControls.city.hasError('required')'>
               The city where the project is locate is <strong>required</strong>
-            </md-error>
-          </md-form-field>
+            </mat-error>
+          </mat-form-field>
         </td>
       </tr>
     </table> -->
 
   <!--FIELD: PROJECT DESCRIPTION-->
-  <md-form-field class='project-full-width'>
-    <textarea mdInput #desc name='DESC' placeholder='{{attributes.DESC.placeholder}}' [formControl]='projectControls.desc'></textarea>
-    <md-error *ngIf='projectControls.desc.hasError("required")'>
+  <mat-form-field class='project-full-width'>
+    <textarea matInput #desc name='DESC' placeholder='{{attributes.DESC.placeholder}}' [formControl]='projectControls.desc'></textarea>
+    <mat-error *ngIf='projectControls.desc.hasError("required")'>
       The description of the project is
       <strong>required</strong>
-    </md-error>
-    <md-hint align='end'>{{desc.value.length}} /400</md-hint>
-  </md-form-field>
+    </mat-error>
+    <mat-hint align='end'>{{desc.value.length}} /400</mat-hint>
+  </mat-form-field>
 
   <!--FIELD: PROJECT TYPE-->
-  <md-form-field class='project-full-width'>
-    <input mdInput #national name='NATIONAL_PROJECT' [formControl]='projectControls.national'>
+  <mat-form-field class='project-full-width'>
+    <input matInput #national name='NATIONAL_PROJECT' [formControl]='projectControls.national'>
     <label class='nat-project-label'>National Project</label>
-    <md-radio-group class="nat-project-radio" (change)='setHiddenInputs("national", $event.value)' #nationalRadios>
-      <md-radio-button value="1">Yes</md-radio-button>
-      <md-radio-button [checked]='true' value="0">No</md-radio-button>
-    </md-radio-group>
-    <md-error *ngIf='projectControls.national.hasError("required")'>Set the type of the
+    <mat-radio-group class="nat-project-radio" (change)='setHiddenInputs("national", $event.value)' #nationalRadios>
+      <mat-radio-button value="1">Yes</mat-radio-button>
+      <mat-radio-button [checked]='true' value="0">No</mat-radio-button>
+    </mat-radio-group>
+    <mat-error *ngIf='projectControls.national.hasError("required")'>Set the type of the
       <strong>project</strong>
-    </md-error>
-  </md-form-field>
+    </mat-error>
+  </mat-form-field>
 
   <!-- FIELD: ORGANIZATION -->
-  <md-form-field class='project-full-width'>
-    <input mdInput name='ORG_ID' class='input-org-id' [formControl]='projectControls.orgId' #orgId>
-    <md-select class='custom-md-select' placeholder="Organization Name" title='Click to select an organization' (change)='setHiddenInputs("orgId", $event.value)'
+  <mat-form-field class='project-full-width'>
+    <input matInput name='ORG_ID' class='input-org-id' [formControl]='projectControls.orgId' #orgId>
+    <mat-select class='custom-mat-select' placeholder="Organization Name" title='Click to select an organization' (change)='setHiddenInputs("orgId", $event.value)'
       #orgIdPicker>
-      <md-option *ngFor="let org of organizations" [value]="org.id" [textContent]='org.name'></md-option>
-    </md-select>
-    <md-error *ngIf='projectControls.orgId.errors'>The organization name is<strong>required</strong></md-error>
-  </md-form-field>
+      <mat-option *ngFor="let org of organizations" [value]="org.id" [textContent]='org.name'></mat-option>
+    </mat-select>
+    <mat-error *ngIf='projectControls.orgId.errors'>The organization name is<strong>required</strong></mat-error>
+  </mat-form-field>
 
   <!-- <div class='project-data-row'>
     <label class='nat-project-label'>National Project</label>
-    <md-radio-group class="nat-project-radio">
-      <md-radio-button value="yes">Yes</md-radio-button>
-      <md-radio-button [checked]='true' value="no">No</md-radio-button>
-    </md-radio-group>
+    <mat-radio-group class="nat-project-radio">
+      <mat-radio-button value="yes">Yes</mat-radio-button>
+      <mat-radio-button [checked]='true' value="no">No</mat-radio-button>
+    </mat-radio-group>
   </div> -->
 
   <!--Button to save the form or Canceled-->
   <div class='buttons-wrapper'>
-    <button md-raised-button color='warn' (mouseup)='hardReset($event, projectForm)'>Cancel</button>
-    <button md-raised-button color='primary'>Validate</button>
-    <!-- <button md-raised-button color='primary' [routerLink]='[projectListLink]' (mouseup)='saveProject()'>Submit -->
+    <button mat-raised-button color='warn' (mouseup)='hardReset($event, projectForm)'>Cancel</button>
+    <button mat-raised-button color='primary'>Validate</button>
+    <!-- <button mat-raised-button color='primary' [routerLink]='[projectListLink]' (mouseup)='saveProject()'>Submit -->
   </div>
 </form>

--- a/src/app/admin/project-form/project-form.component.scss
+++ b/src/app/admin/project-form/project-form.component.scss
@@ -76,7 +76,7 @@
 	margin-bottom: 10px;
 	overflow: hidden;
 
-	md-radio-button {
+	mat-radio-button {
 		margin-right: 10px;
 	}
 }
@@ -91,7 +91,7 @@
 	pointer-events: none;
 }
 
-::ng-deep .custom-md-select .mat-select-underline {
+::ng-deep .custom-mat-select .mat-select-underline {
     display: none;
 }
 

--- a/src/app/admin/project-form/project-form.component.spec.ts
+++ b/src/app/admin/project-form/project-form.component.spec.ts
@@ -3,7 +3,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectFormComponent } from './project-form.component';
 import { SharedModule } from '../../shared/shared.module';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MdDatepickerModule, MdNativeDateModule, MdRadioModule, MdSelectModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { DataService } from '../services/data.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -19,10 +18,6 @@ describe('ProjectFormComponent', () => {
         SharedModule,
         FormsModule,
         ReactiveFormsModule,
-        MdDatepickerModule,
-        MdNativeDateModule,
-        MdRadioModule,
-        MdSelectModule,
         BrowserAnimationsModule,
         RouterTestingModule
       ],

--- a/src/app/admin/project-page/project-page.component.html
+++ b/src/app/admin/project-page/project-page.component.html
@@ -1,32 +1,32 @@
 <div *ngIf="project">
     <h2 class="project-title">{{project.projectName}}</h2>
-    <md-list>
-      <md-list-item class="project-name">
-        <div md-line><div class="label">Name: </div><div class="project-name">{{project.projectName}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-fromDate">
-        <div md-line><div class="label">From Date: </div><div class="project-fromDate">{{project.fromDate}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-toDate">
-        <div md-line><div class="label">To Date: </div><div class="project-toDate">{{project.toDate}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-address">
-        <div md-line><div class="label">Address: </div><div class="project-address">{{project.address}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-neededFunding">
-        <div md-line><div class="label">Needed Funding: </div><div class="project-neededFunding">{{project.neededFunding}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-raisedFunding">
-        <div md-line><div class="label">Raised Funding: </div><div class="project-raisedFunding">{{project.raisedFunding}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-mainImage">
-        <div md-line><div class="label">Main Image: </div><div class="project-mainImage">{{project.mainImage}}</div></div>
-      </md-list-item>
-      <md-list-item class="project-organization" *ngIf="project.organization">
-        <div md-line><div class="label">Organization: </div><div class="project-organization"><a [routerLink]="['/admin/organizations/view/',project.organization.id]" [textContent]='project.organization.name'></a></div></div>
-      </md-list-item>
+    <mat-list>
+      <mat-list-item class="project-name">
+        <div mat-line><div class="label">Name: </div><div class="project-name">{{project.projectName}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-fromDate">
+        <div mat-line><div class="label">From Date: </div><div class="project-fromDate">{{project.fromDate}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-toDate">
+        <div mat-line><div class="label">To Date: </div><div class="project-toDate">{{project.toDate}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-address">
+        <div mat-line><div class="label">Address: </div><div class="project-address">{{project.address}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-neededFunding">
+        <div mat-line><div class="label">Needed Funding: </div><div class="project-neededFunding">{{project.neededFunding}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-raisedFunding">
+        <div mat-line><div class="label">Raised Funding: </div><div class="project-raisedFunding">{{project.raisedFunding}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-mainImage">
+        <div mat-line><div class="label">Main Image: </div><div class="project-mainImage">{{project.mainImage}}</div></div>
+      </mat-list-item>
+      <mat-list-item class="project-organization" *ngIf="project.organization">
+        <div mat-line><div class="label">Organization: </div><div class="project-organization"><a [routerLink]="['/admin/organizations/view/',project.organization.id]" [textContent]='project.organization.name'></a></div></div>
+      </mat-list-item>
       <div class="project-desc">{{project.description}}</div>
-    </md-list>
+    </mat-list>
     <h4>Location: </h4>
     <div class="project-location">
       <agm-map [latitude]="project.location.lat" [longitude]="project.location.lng" [zoom]="12" style="height:300px">

--- a/src/app/donor/donor-overview/donor-overview.component.html
+++ b/src/app/donor/donor-overview/donor-overview.component.html
@@ -1,11 +1,11 @@
 <div class="container" *ngIf="donor">
-  <md-card class="">
+  <mat-card class="">
 
     <div class="image-container">
       <img class="profile-image" [src]="donor.userImage">
     </div>
 
-    <md-card-header class="card-header">
+    <mat-card-header class="card-header">
       <div class="user-info">
         <span class="user-name">{{donor.userName}}</span>
         <br>
@@ -16,11 +16,11 @@
         <span class="donated-amount">Total: {{donor.wallet.total}}</span>
         <span class="amount-left">Donated: {{donor.wallet.donated}}</span>
       </div>
-    </md-card-header>
+    </mat-card-header>
 
     <hr>
 
-  </md-card>
+  </mat-card>
 
   <div class="saved-projects">
     <div class="menu-container">

--- a/src/app/donor/donor-overview/donor-overview.component.scss
+++ b/src/app/donor/donor-overview/donor-overview.component.scss
@@ -24,7 +24,7 @@ $width: 85%;
       margin-top: -20px;
     }
   }
-  md-card {
+  mat-card {
     -webkit-box-shadow: none !important;
     -moz-box-shadow: none !important;
     box-shadow: none !important;
@@ -35,7 +35,7 @@ $width: 85%;
       width: 100%;
     }
 
-    md-card-header {
+    mat-card-header {
       width: $width;
       justify-content: space-between;
       margin: 20px auto;

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="project-list">
     <div class="project-container" *ngFor="let project of projectList">
-      <md-card class="">
+      <mat-card class="">
 
         <div class="main-image-container">
           <img [src]="project.mainImage" [alt]="project.projectName">
@@ -9,22 +9,22 @@
 
         <div class="project-details">
           <div class="button-row">
-            <button md-fab color="white"> <!--(click)="onClick(project.id)"-->
-              <md-icon class="md-24" aria-label="icon-button with a heart icon">favorite</md-icon>
+            <button mat-fab color="white"> <!--(click)="onClick(project.id)"-->
+              <mat-icon class="mat-24" aria-label="icon-button with a heart icon">favorite</mat-icon>
             </button>
           </div>
 
-          <md-card-header class="card-header">
-            <md-card-title class="project-title">{{project.projectName}}</md-card-title>
-            <md-card-subtitle class="project-detail">
+          <mat-card-header class="card-header">
+            <mat-card-title class="project-title">{{project.projectName}}</mat-card-title>
+            <mat-card-subtitle class="project-detail">
               <span class="organization-name">{{project.organizationName}}</span>
               <br>
               <span class="project-address">{{project.address}}</span>
-            </md-card-subtitle>
-          </md-card-header>
+            </mat-card-subtitle>
+          </mat-card-header>
 
 
-          <md-card-content>
+          <mat-card-content>
             <div class="project-description">
               <p class="fade">
                 {{project.description}}
@@ -44,9 +44,9 @@
                 [donateOption3]="donateOption3">
               </app-donate-button>
             </div>
-          </md-card-content>
+          </mat-card-content>
         </div>
-      </md-card>
+      </mat-card>
     </div>
   </div>
 </div>

--- a/src/app/projects/project-list/project-list.component.scss
+++ b/src/app/projects/project-list/project-list.component.scss
@@ -18,7 +18,7 @@ $tablet-desktop: "only screen and (min-width : 420px)";
   height: auto;
   min-height: 100vh;
 
-  md-card {
+  mat-card {
     padding: 0 !important;
 
     .main-image-container {
@@ -51,7 +51,7 @@ $tablet-desktop: "only screen and (min-width : 420px)";
         right: 2em;
         margin-top: -42.5px;
 
-        md-icon {
+        mat-icon {
           color: red;
         }
       }
@@ -98,7 +98,7 @@ $tablet-desktop: "only screen and (min-width : 420px)";
     margin: 0;
     padding-top: 10vh;
 
-    md-card {
+    mat-card {
       -webkit-box-shadow: none !important;
       -moz-box-shadow: none !important;
       box-shadow: none !important;
@@ -122,7 +122,7 @@ $tablet-desktop: "only screen and (min-width : 420px)";
     justify-content: center;
     align-items: flex-start;
 
-    md-card {
+    mat-card {
       width: 450px;
       margin: 2em;
 

--- a/src/app/shared/navbar.component.html
+++ b/src/app/shared/navbar.component.html
@@ -2,18 +2,18 @@
   <div class="nav-menu-container">
     <ul class="navbar-menu">
       <li>
-        <a md-button aria-label="profile" routerLink="/donor">
-          <md-icon aria-hidden="true" class="md-24">person</md-icon>
+        <a mat-button aria-label="profile" routerLink="/donor">
+          <mat-icon aria-hidden="true" class="mat-24">person</mat-icon>
         </a>
       </li>
       <li>
-        <a md-button routerLink="/home" routerLinkActive="active" class="logo">
+        <a mat-button routerLink="/home" routerLinkActive="active" class="logo">
           <img src="../assets/Nano_Logo_White.png" alt="Nano logo">
         </a>
       </li>
       <li>
-        <a md-button aria-label="geo" routerLink="/geo">
-          <md-icon aria-hidden="true" class="md-24">place</md-icon>
+        <a mat-button aria-label="geo" routerLink="/geo">
+          <mat-icon aria-hidden="true" class="mat-24">place</mat-icon>
         </a>
       </li>
     </ul>

--- a/src/app/shared/navbar.component.scss
+++ b/src/app/shared/navbar.component.scss
@@ -37,7 +37,7 @@ nav {
             cursor: pointer;
 
           }
-          md-icon {
+          mat-icon {
             font-size: 4vh;
             color: white;
             cursor: pointer;

--- a/src/app/shared/navbar.component.spec.ts
+++ b/src/app/shared/navbar.component.spec.ts
@@ -1,14 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { NavbarComponent } from './navbar.component';
-import {
-  MdButtonModule,
-  MdCardModule,
-  MdIconModule,
-  MdMenuModule,
-  MdProgressBarModule,
-  MdToolbarModule
-} from '@angular/material';
+import { SharedModule } from './shared.module';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -16,8 +9,8 @@ describe('NavbarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NavbarComponent],
-      imports: [MdCardModule, MdIconModule, MdToolbarModule, MdMenuModule, MdButtonModule, MdProgressBarModule]
+      declarations: [ ],
+      imports: [SharedModule, RouterTestingModule]
     })
     .compileComponents();
   }));

--- a/src/app/shared/progressbar.component.html
+++ b/src/app/shared/progressbar.component.html
@@ -1,5 +1,5 @@
 <div class="progress-bar-container">
   <span>Collected: {{raisedFunding}}</span>
-  <md-progress-bar mode="determinate" [value]='raisedFunding/neededFunding*100'></md-progress-bar>
+  <mat-progress-bar mode="determinate" [value]='raisedFunding/neededFunding*100'></mat-progress-bar>
   <span class="goal">Goal: {{neededFunding}}</span>
 </div>

--- a/src/app/shared/progressbar.component.spec.ts
+++ b/src/app/shared/progressbar.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProgressbarComponent } from './progressbar.component';
-import { MdProgressBarModule } from '@angular/material';
+import { MatProgressBarModule } from '@angular/material';
 
 describe('ProgressbarComponent', () => {
   let component: ProgressbarComponent;
@@ -10,7 +10,7 @@ describe('ProgressbarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ProgressbarComponent ],
-      imports:[MdProgressBarModule]
+      imports:[MatProgressBarModule]
     })
     .compileComponents();
   }));

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,40 +1,76 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { MdCardModule, MdIconModule, MdToolbarModule, MdMenuModule, MdButtonModule, MdProgressBarModule } from '@angular/material';
+import { MatCardModule, 
+         MatIconModule, 
+         MatToolbarModule, 
+         MatMenuModule, 
+         MatButtonModule, 
+         MatProgressBarModule,
+         MatNativeDateModule,
+         MatDatepickerModule,
+         MatRadioModule,
+         MatSelectModule,
+         MatInputModule,
+         MatListModule,
+        } from '@angular/material';
 import { NavbarComponent } from './navbar.component';
 import { ProgressbarComponent } from './progressbar.component';
-import {RouterModule} from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { AgmCoreModule } from '@agm/core';
 import { DonateButtonComponent } from './donate-button/donate-button.component';
+import { FormsModule, 
+         ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserModule } from '@angular/platform-browser';
 
 @NgModule({
   imports: [
+    BrowserAnimationsModule,
+    BrowserModule,
     CommonModule,
     HttpClientModule,
-    MdButtonModule,
-    MdMenuModule,
-    MdToolbarModule,
-    MdIconModule,
-    MdCardModule,
-    MdProgressBarModule,
+    MatButtonModule,
+    MatMenuModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatCardModule,
+    MatProgressBarModule,
+    MatNativeDateModule,
+    MatDatepickerModule,
+    MatRadioModule,
+    MatSelectModule,
+    MatInputModule,
+    MatListModule,
     RouterModule,
+    FormsModule,
+    ReactiveFormsModule,
     AgmCoreModule.forRoot({
       apiKey: 'AIzaSyCHC4hLZ_ogiMaGy9kVZl4u0gjocEyw3EA'
     })
   ],
   exports: [
+    BrowserAnimationsModule,
+    BrowserModule,
     CommonModule,
     HttpClientModule,
-    MdButtonModule,
-    MdMenuModule,
-    MdToolbarModule,
-    MdIconModule,
-    MdCardModule,
-    MdProgressBarModule,
+    MatButtonModule,
+    MatMenuModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatCardModule,
+    MatProgressBarModule,
+    MatNativeDateModule,
+    MatDatepickerModule,
+    MatRadioModule,
+    MatSelectModule,
+    MatInputModule,
+    MatListModule,
     NavbarComponent,
     ProgressbarComponent,
     RouterModule,
+    FormsModule,
+    ReactiveFormsModule,
     AgmCoreModule,
     DonateButtonComponent
   ],


### PR DESCRIPTION
# This is a major update for angular and dependencies, it also includes some code restructuring. 

# Testing instructions:

  - `git pull app-upgrade`
  - `npm install`
  - `ng serve (and check everything)`
  - `ng test (and run all tests)`

# Changes

Updated angular and its libraries from 4.2.4 to 4.4.4
updated angular/cli from 1.3.2 to 1.4.5, and made it updatable.
updated angular/material from 2.0.0-beta.10 to 2.0.0-beta.12
updated zone.js from 0.8.14 to 0.8.18
added webpack as a local dev dependency

updated all references to material modules and components to use the new mat namespace in all modules and components

moved all material imports in admin module to the shared module
moved forms imports from admin module to the shared module
moved browser imports from admin module to the shared module
removed http import from admin module
removed material imports from all spec files as they are imported from the shared module
Fixed imports and declaration in the navbar spec file